### PR TITLE
Add support for xbox guide button

### DIFF
--- a/XInputTest.py
+++ b/XInputTest.py
@@ -19,7 +19,7 @@ class Controller:
         self.on_indicator_pos = (self.center[0], self.center[1] - 50)
 
         self.on_indicator = canvas.create_oval(((self.on_indicator_pos[0] - 10, self.on_indicator_pos[1] - 10), (self.on_indicator_pos[0] + 10, self.on_indicator_pos[1] + 10)))
-        
+
         self.r_thumb_pos = (self.center[0] + 50, self.center[1] + 20)
 
         r_thumb_outline = canvas.create_oval(((self.r_thumb_pos[0] - 25, self.r_thumb_pos[1] - 25), (self.r_thumb_pos[0] + 25, self.r_thumb_pos[1] + 25)))
@@ -112,15 +112,15 @@ while 1:
         controller = controllers[event.user_index]
         if event.type == EVENT_CONNECTED:
             canvas.itemconfig(controller.on_indicator, fill="light green")
-            
+
         elif event.type == EVENT_DISCONNECTED:
             canvas.itemconfig(controller.on_indicator, fill="")
-            
+
         elif event.type == EVENT_STICK_MOVED:
             if event.stick == LEFT:
                 l_thumb_stick_pos = (int(round(controller.l_thumb_pos[0] + 25 * event.x,0)), int(round(controller.l_thumb_pos[1] - 25 * event.y,0)))
                 canvas.coords(controller.l_thumb_stick, (l_thumb_stick_pos[0] - 10, l_thumb_stick_pos[1] - 10, l_thumb_stick_pos[0] + 10, l_thumb_stick_pos[1] + 10))
-                
+
             elif event.stick == RIGHT:
                 r_thumb_stick_pos = (int(round(controller.r_thumb_pos[0] + 25 * event.x,0)), int(round(controller.r_thumb_pos[1] - 25 * event.y,0)))
                 canvas.coords(controller.r_thumb_stick, (r_thumb_stick_pos[0] - 10, r_thumb_stick_pos[1] - 10, r_thumb_stick_pos[0] + 10, r_thumb_stick_pos[1] + 10))
@@ -148,6 +148,8 @@ while 1:
                 canvas.itemconfig(controller.back_button, fill="red")
             elif event.button == "START":
                 canvas.itemconfig(controller.start_button, fill="red")
+            elif event.button == "GUIDE":
+                canvas.itemconfig(controller.on_indicator, fill="red")
 
             elif event.button == "DPAD_LEFT":
                 canvas.itemconfig(controller.dpad_left, fill="red")
@@ -182,6 +184,8 @@ while 1:
                 canvas.itemconfig(controller.back_button, fill="")
             elif event.button == "START":
                 canvas.itemconfig(controller.start_button, fill="")
+            elif event.button == "GUIDE":
+                canvas.itemconfig(controller.on_indicator, fill="light green")
 
             elif event.button == "DPAD_LEFT":
                 canvas.itemconfig(controller.dpad_left, fill="")
@@ -201,7 +205,7 @@ while 1:
             elif event.button == "X":
                 canvas.itemconfig(controller.X_button, fill="")
 
-    try:          
+    try:
         root.update()
     except tk.TclError:
         break

--- a/XInputThreadTest.py
+++ b/XInputThreadTest.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     root.title("XInput")
     canvas = tk.Canvas(root, width= 600, height = 400, bg="white")
     canvas.pack()
-    
+
     set_deadzone(DEADZONE_TRIGGER,10)
 
     class Controller:
@@ -24,7 +24,7 @@ if __name__ == "__main__":
             self.on_indicator_pos = (self.center[0], self.center[1] - 50)
 
             self.on_indicator = canvas.create_oval(((self.on_indicator_pos[0] - 10, self.on_indicator_pos[1] - 10), (self.on_indicator_pos[0] + 10, self.on_indicator_pos[1] + 10)))
-            
+
             self.r_thumb_pos = (self.center[0] + 50, self.center[1] + 20)
 
             r_thumb_outline = canvas.create_oval(((self.r_thumb_pos[0] - 25, self.r_thumb_pos[1] - 25), (self.r_thumb_pos[0] + 25, self.r_thumb_pos[1] + 25)))
@@ -135,6 +135,10 @@ if __name__ == "__main__":
                 canvas.itemconfig(controller.back_button, fill=fill_color)
             elif event.button == "START":
                 canvas.itemconfig(controller.start_button, fill=fill_color)
+            elif event.button == "GUIDE":
+                if fill_color == "":
+                    fill_color = "light green"
+                canvas.itemconfig(controller.on_indicator, fill=fill_color)
 
             elif event.button == "DPAD_LEFT":
                 canvas.itemconfig(controller.dpad_left, fill=fill_color)
@@ -153,13 +157,13 @@ if __name__ == "__main__":
                 canvas.itemconfig(controller.Y_button, fill=fill_color)
             elif event.button == "X":
                 canvas.itemconfig(controller.X_button, fill=fill_color)
-        
+
         def process_stick_event(self, event):
             controller = controllers[event.user_index]
             if event.stick == LEFT:
                 l_thumb_stick_pos = (int(round(controller.l_thumb_pos[0] + 25 * event.x,0)), int(round(controller.l_thumb_pos[1] - 25 * event.y,0)))
                 canvas.coords(controller.l_thumb_stick, (l_thumb_stick_pos[0] - 10, l_thumb_stick_pos[1] - 10, l_thumb_stick_pos[0] + 10, l_thumb_stick_pos[1] + 10))
-                
+
             elif event.stick == RIGHT:
                 r_thumb_stick_pos = (int(round(controller.r_thumb_pos[0] + 25 * event.x,0)), int(round(controller.r_thumb_pos[1] - 25 * event.y,0)))
                 canvas.coords(controller.r_thumb_stick, (r_thumb_stick_pos[0] - 10, r_thumb_stick_pos[1] - 10, r_thumb_stick_pos[0] + 10, r_thumb_stick_pos[1] + 10))
@@ -197,8 +201,8 @@ if __name__ == "__main__":
 
         def process_connection_event(self, event):
             pass
-    
-    
+
+
     handler = MyHandler(0, 1, 2, 3)        # initialize handler object
     thread = GamepadThread(handler)                 # initialize controller thread
 


### PR DESCRIPTION
This PR adds the xbox guide button support.

I'm calling the xinput function by ordinal as described in this post: http://reverseengineerlog.blogspot.com/2016/06/xinputs-hidden-functions.html

Also, this xinput wrapper for AutoHotKey use this to be able to get the guide button: https://www.autohotkey.com/boards/viewtopic.php?t=29659#:~:text=XInput.,triggers%20are%20pulled%20at%20once.

```
(_XInput_GetState        := DllCall("GetProcAddress" ,"ptr",_XInput_hm ,"ptr",100 ,"ptr"))
|| (_XInput_GetState        := DllCall("GetProcAddress" ,"ptr",_XInput_hm ,"astr","XInputGetState" ,"ptr"))
```

I took the liberty to update the example code as well. Hope this PR is helpfull.